### PR TITLE
get_name() changes to handle class property case

### DIFF
--- a/pytool/json.py
+++ b/pytool/json.py
@@ -10,7 +10,11 @@ into JSON automatically.
 """
 from datetime import datetime
 
-import simplejson as json
+try:
+    import simplejson as json
+except:
+    import json
+
 # Conditionally handle bson import so we don't have to depend on pymongo
 try:
     import bson

--- a/pytool/lang.py
+++ b/pytool/lang.py
@@ -31,10 +31,12 @@ def get_name(frame):
             maybe_cls = frame.f_locals[varname]
 
             # Get the actual method, if it exists on the class
-            maybe_func = maybe_cls.__class__.__dict__[frame.f_code.co_name]
-
+            if isinstance(maybe_cls, type):
+                maybe_func = maybe_cls.__dict__[frame.f_code.co_name]
+            else:
+                maybe_func = maybe_cls.__class__.__dict__[frame.f_code.co_name]
             # If we have self, or a classmethod, we need the class name
-            if (varname == 'self' or maybe_func.im_self == maybe_cls):
+            if (varname in ('self', 'cls') or maybe_func.im_self == maybe_cls):
                 cls_name = (getattr(maybe_cls, '__name__', None)
                         or getattr(getattr(maybe_cls, '__class__', None),
                             '__name__', None))

--- a/pytool/lang.py
+++ b/pytool/lang.py
@@ -31,7 +31,7 @@ def get_name(frame):
             maybe_cls = frame.f_locals[varname]
 
             # Get the actual method, if it exists on the class
-            maybe_func = getattr(maybe_cls, frame.f_code.co_name)
+            maybe_func = maybe_cls.__class__.__dict__[frame.f_code.co_name]
 
             # If we have self, or a classmethod, we need the class name
             if (varname == 'self' or maybe_func.im_self == maybe_cls):
@@ -236,7 +236,7 @@ class UNSET(object):
             >>> # Is good for checking default values
             >>> if {}.get('example', UNSET) is UNSET:
             ...     print "Key is missing."
-            ...     
+            ...
             Key is missing.
             >>> # Has no length
             >>> len(UNSET)
@@ -285,7 +285,7 @@ class Namespace(object):
         >>> # Namespaces are iterable
         >>> for name, value in myns:
         ...     print name, value
-        ...     
+        ...
         hello world
         example.value True
         >>> # Namespaces that are empty evaluate as False
@@ -300,7 +300,7 @@ class Namespace(object):
         >>> class MyDescriptor(object):
         ...     def __get__(self, instance, owner):
         ...         return 'Hello World'
-        ...     
+        ...
         >>> myns.descriptor = MyDescriptor()
         >>> myns.descriptor
         'Hello World'

--- a/test/test_lang.py
+++ b/test/test_lang.py
@@ -35,6 +35,17 @@ def test_get_name_class():
     Test().test()
 
 
+def test_get_name_class_property():
+    class Test(object):
+        @property
+        def test(self):
+            frame = inspect.currentframe()
+            this_name = pytool.lang.get_name(frame)
+            del frame
+            return this_name
+    eq_(Test().test, 'Test.test')
+
+
 def test_classproperty():
     class Test(object):
         value = 'Test'

--- a/test/test_lang.py
+++ b/test/test_lang.py
@@ -43,7 +43,7 @@ def test_get_name_class_property():
             this_name = pytool.lang.get_name(frame)
             del frame
             return this_name
-    eq_(Test().test, 'Test.test')
+    eq_(Test().test, 'test.test_lang.Test.test')
 
 
 def test_classproperty():

--- a/test/test_lang.py
+++ b/test/test_lang.py
@@ -35,6 +35,18 @@ def test_get_name_class():
     Test().test()
 
 
+def test_get_name_class_method():
+    class Test(object):
+        @classmethod
+        def test(cls):
+            frame = inspect.currentframe()
+            eq_(pytool.lang.get_name(frame),
+                    'test.test_lang.Test.test')
+            del frame
+
+    Test.test()
+
+
 def test_get_name_class_property():
     class Test(object):
         @property


### PR DESCRIPTION
The get_name() code resulted in a RuntimeError (due to deep recursion), if the passed frame referred to a class property. The main fix was to not use getattr(), since that resulted in executing the property get code. This pull request contains the updated get_name() as well as two new test cases.

