### PR TITLE
Fixed 1 issue of type: PYTHON_W391 throughout 1 file in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,3 @@ setup(
             'Topic :: Utilities',
             ]
         )
-


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.