### PR TITLE
Add manifest file to add the license to the bundled package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.rst


### PR DESCRIPTION
Added the manifest file to ensure the license gets added to the bundled package. 

This was requested bij the conda-forge maintainer, see comment: https://github.com/conda-forge/staged-recipes/pull/16516#discussion_r730302912

This is done to make pytool installable as a conda package.